### PR TITLE
Improve Gitlab-CI

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -94,6 +94,7 @@ module.exports = yeoman.generators.Base.extend({
     }
 
     if (this.ciType == "gitlabci") {
+      jhipsterFunc.addBowerrcParameter('allow_root', true);
       this.template('.gitlab-ci.yml', '.gitlab-ci.yml', this, {});
     }
 

--- a/generators/app/templates/.gitlab-ci.yml
+++ b/generators/app/templates/.gitlab-ci.yml
@@ -1,7 +1,8 @@
-image: jdubois/jhipster-docker:latest
+image: moifort/jhipster-gitlab-ci-image:2.26.1-cache
 
 before_script:
-  - npm install phantomjs
+  - cp -r /root/node_modules .
+  - npm install
 
 stages:
   - build


### PR DESCRIPTION
- Specific JHipster image with cache (maven + node_modules) [Github](https://github.com/moifort/jhipster-gitlab-ci-image) & [Docker](https://hub.docker.com/r/moifort/jhipster-gitlab-ci-image/tags/). 
- New configuration with `.gitlab-ci.json` file
- add `.bowerrc` option, because is not working with my image. Need to wait the PR https://github.com/jhipster/generator-jhipster/pull/2540.

@atomfrede can you test when the PR will be merged? (sorry but I didn't cache the gradle file, but there is an [issue](https://github.com/moifort/jhipster-gitlab-ci-image/issues/1) :smile:) 

Link #4 
