### PR TITLE
Gitlab ci fixes

### DIFF
--- a/generators/app/templates/.gitlab-ci.yml
+++ b/generators/app/templates/.gitlab-ci.yml
@@ -24,8 +24,8 @@ stages:
 
 before_script:
   - export GRADLE_USER_HOME=`pwd`/.gradle
-  - export MAVEN_USER_HOME=`pwd`/.maven
-  - npm install
+  - export MAVEN_USER_HOME=`pwd`/.maven <%_ if (!skipClient) { _%>
+  - npm install <%_ } _%>
 
 <%_ if (buildTool == 'gradle') { _%>
 gradle-build:
@@ -51,8 +51,8 @@ gatling-test:
     allow_failure: true
     script:
         - ./gradlew gatlingRun -x cleanResources --no-daemon
-    before_script:
-        - npm install
+    before_script: <%_ if (!skipClient) { _%>
+        - npm install <%_ } _%>
         - ./gradlew bootRun &
     artifacts:
         paths:
@@ -90,8 +90,8 @@ gatling-test:
     allow_failure: true
     script:
         - ./mvnw gatling:execute -Dmaven.repo.local=$MAVEN_USER_HOME
-    before_script:
-        - npm install
+    before_script: <%_ if (!skipClient) { _%>
+        - npm install <%_ } _%>
         - ./mvnw &
     artifacts:
         paths:

--- a/generators/app/templates/.gitlab-ci.yml
+++ b/generators/app/templates/.gitlab-ci.yml
@@ -1,13 +1,20 @@
 image: atomfrede/gitlab-ci-jhipster-stack
 
+<%_ if (buildTool == 'gradle') { _%>
 cache:
   key: "$CI_BUILD_REF_NAME"
   paths:
     - node_modules
     - .gradle/wrapper
     - .gradle/caches
+<%_ } _%>
+<%_ if (buildTool == 'maven') { _%>
+cache:
+  key: "$CI_BUILD_REF_NAME"
+  paths:
+    - node_modules
     - .maven
-
+<%_ } _%>
 stages:
   - build
   - test
@@ -88,7 +95,7 @@ gatling-test:
         - ./mvnw &
     artifacts:
         paths:
-            - target/reports/gatling/*
+            - target/gatling/*
 <%_ } _%>
 maven-package:
     stage: package


### PR DESCRIPTION
- Correct gatling report path for maven
- Don't do nom-install when client was skipped
- Don't try to cache maven files when using gradle and vice versa

Examples can be found here: 
- https://gitlab.com/atomfrede/jhipster-ci-example-maven
- https://gitlab.com/atomfrede/jhipster-ci-example-gradle
